### PR TITLE
Fix `grunt build`

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -52,9 +52,6 @@ module.exports = function(grunt) {
                     'union',
                     'uniqueId',
                     'values',
-                ],
-                flags: [
-                    '--debug'
                 ]
             }
         },

--- a/package.json
+++ b/package.json
@@ -13,23 +13,23 @@
     "tests"
   ],
   "devDependencies": {
-    "grunt": "~0.4.1",
-    "grunt-contrib-qunit": "~0.2.2",
-    "grunt-cli": "~0.1.9",
-    "lodash": "~2.0.0",
-    "closure-compiler": "~0.2.2",
-    "uglify-js": "~2.4.0",
-    "grunt-contrib-uglify": "~0.2.4",
-    "grunt-modernizr": "~0.3.0",
-    "grunt-lodash": "~0.3.0",
-    "grunt-bower-task": "~0.3.2",
-    "grunt-shell": "~0.3.1",
-    "jison": "~0.4.13",
-    "jquery-builder": "~0.5.0",
-    "phantomjs": "~1.9.2-0",
-    "grunt-casperjs": "~1.0.9"
+    "grunt": "~0.4.5",
+    "grunt-contrib-qunit": "~0.5.2",
+    "grunt-cli": "~0.1.13",
+    "lodash": "~3.2.0",
+    "closure-compiler": "~0.2.6",
+    "uglify-js": "~2.4.16",
+    "grunt-contrib-uglify": "~0.7.0",
+    "grunt-modernizr": "~0.6.0",
+    "grunt-lodash": "~0.4.0",
+    "grunt-bower-task": "~0.4.0",
+    "grunt-shell": "~1.1.1",
+    "jison": "~0.4.15",
+    "jquery-builder": "~0.7.0",
+    "phantomjs": "~1.9.15",
+    "grunt-casperjs": "~2.1.0"
   },
   "dependencies": {
-    "bower": "~1.2.6"
+    "bower": "~1.3.12"
   }
 }


### PR DESCRIPTION
This is the sledgehammer approach to fixing this, but here goes for
documentation purposes that people can find via google on a rejected
pull request if nothing else.

After doing `npm install; grunt build`[1] as per the README, I was
getting this error:

```
Running "bower:install" (bower) task
Fatal error: Arguments to path.join must be strings
```

A bit of googling suggests that it's a known issue with some particular
version of grunt or its dependencies. I fixed it by removing all the
version numbers from package.json and running this:

```
npm install --save bower
npm install --save-dev \
    grunt \
    grunt-contrib-qunit \
    grunt-cli \
    lodash \
    closure-compiler \
    uglify-js \
    grunt-contrib-uglify \
    grunt-modernizr \
    grunt-lodash \
    grunt-bower-task \
    grunt-shell \
    jison \
    jquery-builder \
    phantomjs \
    grunt-casperjs
```

(that is, listing all the packages in the `dependencies` and
`devDependencies` fields of package.json.

Once that error was overcome, I was getting this:

```
Running "lodash:build" (lodash) task
>> Error:
>> Invalid argument passed: --debug
>> For more information type: lodash --help
Warning:
Invalid argument passed: --debug
For more information type: lodash --help Use --force to continue.
```

...which I fixed with the change to Gruntfile.js.

[1] Actually I do
    `npm install; PATH=$(pwd)/node_modules/.bin:$PATH grunt build`
    because I don't want to install grunt globally.
